### PR TITLE
Adds native module to start activity and signing wrapper

### DIFF
--- a/SignWithApp.js
+++ b/SignWithApp.js
@@ -1,0 +1,35 @@
+import {
+  NativeModules,
+  Platform
+} from 'react-native';
+
+requestCode = 0;
+
+async function signWithApp(form) {
+  if (Platform.OS === 'ios') {
+    console.warn('iOS is not supported.');
+    return null;
+  }
+
+  const { StartActivity } = NativeModules;
+  const action = "com.ixosign.SIGN";
+  const componentName = await StartActivity.resolveActivity(action);
+  if (!componentName) {
+    // TODO: send link to app store?
+    console.warn("Cannot resolve signing activity. Did you install the signing app?");
+    return null;
+  }
+
+  const response = await StartActivity.startActivityForResult(
+    ++requestCode, 
+    action,
+    { content: form });
+
+  if (response.resultCode !== StartActivity.OK) {
+    throw new Error('Invalid result from sign activity.');
+  }
+
+  return response.data.content;
+};
+
+export default sign;

--- a/android/app/src/main/java/com/ixomobile/IxoMobileReactPackage.java
+++ b/android/app/src/main/java/com/ixomobile/IxoMobileReactPackage.java
@@ -1,0 +1,24 @@
+package com.ixomobile;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class IxoMobileReactPackage implements ReactPackage {
+    @Override
+    public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
+        return Arrays.<NativeModule>asList(
+            new StartActivityModule(reactContext)
+        );
+    }
+
+    @Override
+    public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+        return Collections.emptyList();
+    }
+}

--- a/android/app/src/main/java/com/ixomobile/MainApplication.java
+++ b/android/app/src/main/java/com/ixomobile/MainApplication.java
@@ -24,7 +24,8 @@ public class MainApplication extends Application implements ReactApplication {
     protected List<ReactPackage> getPackages() {
       return Arrays.<ReactPackage>asList(
           new MainReactPackage(),
-          new RandomBytesPackage()
+          new RandomBytesPackage(),
+          new IxoMobileReactPackage()
       );
     }
 

--- a/android/app/src/main/java/com/ixomobile/StartActivityModule.java
+++ b/android/app/src/main/java/com/ixomobile/StartActivityModule.java
@@ -1,0 +1,107 @@
+package com.ixomobile;
+
+import android.app.Activity;
+import android.content.ComponentName;
+import android.content.Intent;
+import android.util.SparseArray;
+
+import com.facebook.react.bridge.ActivityEventListener;
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.bridge.WritableNativeMap;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.ResourceBundle;
+
+import javax.annotation.Nullable;
+
+public class StartActivityModule extends ReactContextBaseJavaModule implements ActivityEventListener {
+
+    final SparseArray<Promise> mPromises;
+
+    public StartActivityModule(ReactApplicationContext reactContext) {
+        super(reactContext);
+        mPromises = new SparseArray<>();
+    }
+
+    @Override
+    public String getName() {
+        return "StartActivity";
+    }
+
+    @Nullable
+    @Override
+    public Map<String, Object> getConstants() {
+        HashMap<String, Object> constants = new HashMap<>();
+        constants.put("OK", Activity.RESULT_OK);
+        constants.put("CANCELED", Activity.RESULT_CANCELED);
+        return constants;
+    }
+
+    @Override
+    public void initialize() {
+        super.initialize();
+        getReactApplicationContext().addActivityEventListener(this);
+    }
+
+    @Override
+    public void onCatalystInstanceDestroy() {
+        super.onCatalystInstanceDestroy();
+        getReactApplicationContext().removeActivityEventListener(this);
+    }
+
+    @ReactMethod
+    public void startActivity(String action, ReadableMap data) {
+        Activity activity = getReactApplicationContext().getCurrentActivity();
+        Intent intent = new Intent(action);
+        intent.putExtras(Arguments.toBundle(data));
+        activity.startActivity(intent);
+    }
+
+    @ReactMethod
+    public void startActivityForResult(int requestCode, String action, ReadableMap data, Promise promise) {
+        Activity activity = getReactApplicationContext().getCurrentActivity();
+        Intent intent = new Intent(action);
+        intent.putExtras(Arguments.toBundle(data));
+        activity.startActivityForResult(intent, requestCode);
+        mPromises.put(requestCode, promise);
+    }
+
+    @ReactMethod
+    public void resolveActivity(String action, Promise promise) {
+        Activity activity = getReactApplicationContext().getCurrentActivity();
+        Intent intent = new Intent(action);
+        ComponentName componentName = intent.resolveActivity(activity.getPackageManager());
+        if (componentName == null) {
+            promise.resolve(null);
+            return;
+        }
+
+        WritableMap map = new WritableNativeMap();
+        map.putString("class", componentName.getClassName());
+        map.putString("package", componentName.getPackageName());
+        promise.resolve(map);
+    }
+
+    @Override
+    public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {
+        Promise promise = mPromises.get(requestCode);
+        if (promise != null) {
+            WritableMap result = new WritableNativeMap();
+            result.putInt("resultCode", resultCode);
+            result.putMap("data", Arguments.makeNativeMap(data.getExtras()));
+            promise.resolve(result);
+        }
+    }
+
+    @Override
+    public void onNewIntent(Intent intent) {
+        /* Do nothing */
+    }
+}


### PR DESCRIPTION
This change set adds a native module that can be used to start an activity for a result. Specifically, this native module will allow us to kick off an intent that will open the app used to sign the completed template. The native module is set up as a promise, so you can await the response from the sign app. It also adds a wrapper to invoke the IXO signing app.